### PR TITLE
Fixed exception in the case where _csrf_token is not available in Flask.g

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -235,7 +235,7 @@ class SeaSurf(object):
         return the response unaltered. Bound to the Flask `after_request`
         decorator.'''
 
-        if getattr(g, self._csrf_name) is None:
+        if getattr(g, self._csrf_name, None) is None:
             return response
 
         if not getattr(g, '_csrf_used', False):


### PR DESCRIPTION
It fixed the following error:

Traceback (most recent call last):
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask/app.py", line 1701, in **call**
    return self.wsgi_app(environ, start_response)
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask/app.py", line 1689, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask/app.py", line 1687, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask/app.py", line 1362, in full_dispatch_request
    response = self.process_response(response)
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask/app.py", line 1564, in process_response
    response = handler(response)
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/flask_seasurf.py", line 238, in _after_request
    if getattr(g, self._csrf_name) is None:
  File "/Users/user/.virtualenvs/project/lib/python2.7/site-packages/werkzeug/local.py", line 336, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: '_RequestGlobals' object has no attribute '_csrf_token'
