### PR TITLE
Remove Jinja2 dependency for better AJAX support

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -207,12 +207,12 @@ class SeaSurf(object):
             setattr(g, self._csrf_name, csrf_token)
        
         # Always set this to let the response know whether or not to set the CSRF token
-        setattr(g, 'view_func', self.app.view_functions.get(request.endpoint))
+        g._view_func = self.app.view_functions.get(request.endpoint)
 
         if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
             # Retrieve the view function based on the request endpoint and
             # then compare it to the set of exempted views
-            if self._should_use_token(g.view_func) == False:
+            if not self._should_use_token(g._view_func):
                 return
 
             if request.is_secure:
@@ -254,8 +254,8 @@ class SeaSurf(object):
         if getattr(g, self._csrf_name, None) is None:
             return response
         
-        view_func = getattr(g, 'view_func', None)
-        if not (view_func and self._should_use_token(view_func)):
+        _view_func = getattr(g, '_view_func', False)
+        if not (_view_func and self._should_use_token(_view_func)):
             return response
 
         response.set_cookie(self._csrf_name,


### PR DESCRIPTION
Currently, flask-seasurf will only send the client a cookie containing a CSRF token if someone has called the _get_token() function, usually from a Jinja2 view.

If you are doing AJAX requests and don't use the Jinja2 tag `{{ csrf_token }}` - that is, if you just want to use the value in the cookie for doing some AJAX after loading a CSRF-protected view, this change lets you do that.

It adds a bit of the request context into the application global `g` so that the response can know whether or not it should include a cookie. I thought that it would be reasonable to set the cookie on the response if the page should be protected per the app config.

Because all views that are protected per the config can now get the cookie upon render, there is no need to check and see if someone actually used the `csrf_token` tag. Previously, the 'used' flag was never set, meaning the cookie never got set.
