### PR TITLE
Don't check CSRF token for 404 not found requests

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -170,7 +170,7 @@ class SeaSurf(object):
         '''Given a view function, determine whether or not we should
         deliver a CSRF token to this view through the response and
         validate CSRF tokens upon requests to this view.'''
-        if view is None:
+        if view_func is None:
             return False
         view = '%s.%s' % (view_func.__module__, view_func.__name__)
         if self._type == 'exempt':


### PR DESCRIPTION
...exist. This can happen for example when a non-GET request will generate a 404 not found response.
