### PR TITLE
Don't write session unless it's modified

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -299,9 +299,11 @@ class SeaSurf(object):
         if not (_view_func and self._should_use_token(_view_func)):
             return response
 
-        session[self._csrf_name] = getattr(_app_ctx_stack.top, self._csrf_name)
+        csrf_token = getattr(_app_ctx_stack.top, self._csrf_name)
+        if session.get(self._csrf_name) != csrf_token:
+            session[self._csrf_name] = csrf_token
         response.set_cookie(self._csrf_name,
-                            getattr(_app_ctx_stack.top, self._csrf_name),
+                            csrf_token,
                             max_age=self._csrf_timeout,
                             secure=self._csrf_secure,
                             httponly=self._csrf_httponly,

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -274,6 +274,9 @@ class SeaSurfTestCaseSave(unittest.TestCase):
             self.assertIn(b('bar'), rv.data)
             self.assertEqual(rv.headers['X-Session-Modified'], 'False')
 
+    def assertIn(self, value, container):
+        self.assertTrue(value in container)
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -240,6 +240,40 @@ class SeaSurfTestCaseExemptUrls(unittest.TestCase):
     def assertIn(self, value, container):
         self.assertTrue(value in container)
 
+class SeaSurfTestCaseSave(unittest.TestCase):
+    def setUp(self):
+        app = Flask(__name__)
+        app.debug = True
+        app.secret_key = '1234'
+        self.app = app
+
+        @app.after_request
+        def after_request(response):
+            from flask import session
+            response.headers['X-Session-Modified'] = str(session.modified)
+            return response
+
+        csrf = SeaSurf()
+        csrf._csrf_disable = False
+        self.csrf = csrf
+
+        # Initialize CSRF protection.
+        self.csrf.init_app(app)
+
+        @app.route('/foo', methods=['GET'])
+        def foo():
+            return 'bar'
+
+    def test_save(self):
+        with self.app.test_client() as client:
+            rv = client.get('/foo')
+            self.assertIn(b('bar'), rv.data)
+            self.assertEqual(rv.headers['X-Session-Modified'], 'True')
+
+            rv = client.get('/foo')
+            self.assertIn(b('bar'), rv.data)
+            self.assertEqual(rv.headers['X-Session-Modified'], 'False')
+
 
 def suite():
     suite = unittest.TestSuite()
@@ -247,6 +281,7 @@ def suite():
     suite.addTest(unittest.makeSuite(SeaSurfTestCaseExemptViews))
     suite.addTest(unittest.makeSuite(SeaSurfTestCaseIncludeViews))
     suite.addTest(unittest.makeSuite(SeaSurfTestCaseExemptUrls))
+    suite.addTest(unittest.makeSuite(SeaSurfTestCaseSave))
     return suite
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some session backends only save the session if it was modified. Flask-Seasurf therefore shouldn't modify the session on every request.

Patch + test included.