### PR TITLE
option to disable Referer check

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,6 +75,11 @@ exempt decorator. For instance it's possible to decorate a view as shown below:
         '''This view is exempted from CSRF validation.'''
         return 'foobar'
 
+By default when a request is determinded to be secure, i.e. using HTTPS, then
+we use strict referer checking to prevent a man-in-the-middle attack from being
+plausible. To disable checking the Referer header, set the Flask app's config
+`CSRF_CHECK_REFERER` to `False`.
+
 
 AJAX Usage
 ----------

--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -134,6 +134,7 @@ class SeaSurf(object):
         self._csrf_secure = app.config.get('CSRF_COOKIE_SECURE', False)
         self._csrf_httponly = app.config.get('CSRF_COOKIE_HTTPONLY', False)
         self._csrf_domain = app.config.get('CSRF_COOKIE_DOMAIN')
+        self._check_referer = app.config.get('CSRF_CHECK_REFERER', True)
         self._type = app.config.get('SEASURF_INCLUDE_OR_EXEMPT_VIEWS',
                                     'exempt')
 
@@ -242,7 +243,7 @@ class SeaSurf(object):
             if not self._should_use_token(_app_ctx_stack.top._view_func):
                 return
 
-            if request.is_secure:
+            if request.is_secure and self._check_referer:
                 referer = request.headers.get('Referer')
                 if referer is None:
                     error = (REASON_NO_REFERER, request.path)


### PR DESCRIPTION
Fixes #46.

Adds a new Flask app config `CSRF_CHECK_REFERER` which defaults to `True`.

Adds one new test for `CSRF_CHECK_REFERER` set to `False` to make sure a request succeeds when the Referer header is invalid.