### PR TITLE
improve test coverage and prevent hijacking requests with invalid json

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -25,7 +25,7 @@ import random
 from datetime import timedelta
 
 from flask import _app_ctx_stack, current_app, request, session
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import BadRequest, Forbidden
 from werkzeug.security import safe_str_cmp
 
 
@@ -270,8 +270,12 @@ class SeaSurf(object):
             request_csrf_token = request.form.get(self._csrf_name, '')
             if request_csrf_token == '':
                 # Check to see if the data is being sent as JSON
-                if hasattr(request, 'json') and request.json:
-                    request_csrf_token = request.json.get(self._csrf_name, '')
+                try:
+                    if hasattr(request, 'json') and request.json:
+                        request_csrf_token = request.json.get(self._csrf_name,\
+                                                                '')
+                except BadRequest:
+                    pass
 
             if request_csrf_token == '':
                 # As per the Django middleware, this makes AJAX easier and

--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -273,7 +273,7 @@ class SeaSurf(object):
                 try:
                     if hasattr(request, 'json') and request.json:
                         request_csrf_token = request.json.get(self._csrf_name,\
-                                                                '')
+                                                              '')
                 except BadRequest:
                     pass
 


### PR DESCRIPTION
Adds tests for:

* passing the csrf token in the `X-CSRFToken` header
* passing the csrf token in form encoded data
* prevent hijacking requests with invalid json (in py3 flask returns a 400 response when Flask-SeaSurf accesses `request.json` while it should be up to the user's route function to access the json data or not).