### PR TITLE
Except json.get error for JSON list data

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -274,7 +274,8 @@ class SeaSurf(object):
                     if hasattr(request, 'json') and request.json:
                         request_csrf_token = request.json.get(self._csrf_name,\
                                                               '')
-                except BadRequest:
+                # Except Attribute error if JSON data is a list
+                except (BadRequest, AttributeError):
                     pass
 
             if request_csrf_token == '':


### PR DESCRIPTION
Fixes #64 

Adds `AttributeError` to the exceptions for trying to read JSON data from the request in `_before_request` in order to support the case where JSON data is solely a list. If the JSON data is a list, we assume that it does not contain the `request_csrf_token` and move forward to look for the token in the headers.