### PR TITLE
Ability to disable CSRF for OAuth requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
-install: pip install flask && pip install nose
+install:
+  - pip install flask && pip install nose
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
 script: python setup.py test
 


### PR DESCRIPTION
For OAuth requests the client is re-authenticating every request and doesn't need CSRF protection. However, using `@csrf.exempt` is dangerous because we don't want to disable CSRF protection for non-OAuth requests to that view.

This adds the ability to disable/enable CSRF protection and setting the CSRF Token cookie on a per-request basis so the same view can handle both OAuth and regular requests.