### PR TITLE
Send Set-Cookie header(much) less often to reduce breaking cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 2.6
   - 2.7
   - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 install: pip install flask && pip install nose
 script: python setup.py test
 

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -13,7 +13,19 @@ else:
     b = lambda s: s.encode('utf-8')
 
 
-class SeaSurfTestCase(unittest.TestCase):
+class BaseTestCase(unittest.TestCase):
+    # Methods for backwards compatibility with python 2.5 & 2.6
+    def assertIn(self, value, container, err=None):
+        self.assertTrue(value in container, err)
+
+    def assertNotIn(self, value, container, err=None):
+        self.assertTrue(value not in container, err)
+
+    def assertIsNotNone(self, value, err=None):
+        self.assertNotEqual(value, None, err)
+
+
+class SeaSurfTestCase(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -201,15 +213,8 @@ class SeaSurfTestCase(unittest.TestCase):
                              headers=headers)
             self.assertEqual(rv.status_code, 200, rv)
 
-    # Methods for backwards compatibility with python 2.5 & 2.6
-    def assertIn(self, value, container):
-        self.assertTrue(value in container)
 
-    def assertIsNotNone(self, value):
-        self.assertNotEqual(value, None)
-
-
-class SeaSurfTestCaseExemptViews(unittest.TestCase):
+class SeaSurfTestCaseExemptViews(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -247,7 +252,7 @@ class SeaSurfTestCaseExemptViews(unittest.TestCase):
         self.assertTrue(value in container)
 
 
-class SeaSurfTestCaseIncludeViews(unittest.TestCase):
+class SeaSurfTestCaseIncludeViews(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -293,7 +298,7 @@ class SeaSurfTestCaseIncludeViews(unittest.TestCase):
         self.assertTrue(value in container)
 
 
-class SeaSurfTestCaseExemptUrls(unittest.TestCase):
+class SeaSurfTestCaseExemptUrls(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -336,7 +341,7 @@ class SeaSurfTestCaseExemptUrls(unittest.TestCase):
         self.assertTrue(value in container)
 
 
-class SeaSurfTestCaseSave(unittest.TestCase):
+class SeaSurfTestCaseSave(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -374,7 +379,7 @@ class SeaSurfTestCaseSave(unittest.TestCase):
         self.assertTrue(value in container)
 
 
-class SeaSurfTestCaseReferer(unittest.TestCase):
+class SeaSurfTestCaseReferer(BaseTestCase):
     def setUp(self):
         app = Flask(__name__)
         app.debug = True
@@ -424,7 +429,7 @@ class SeaSurfTestCaseReferer(unittest.TestCase):
             self.assertEqual(200, rv.status_code)
 
 
-class SeaSurfTestCaseSetCookie(unittest.TestCase):
+class SeaSurfTestCaseSetCookie(BaseTestCase):
     '''
     Tests the Set-Cookie header behavior
 


### PR DESCRIPTION
The current behavior of Flask-SeaSurf causes it to send a Set-Cookie header on every request unless the view function is wrapped in `@csrf.exempt` or `SEASURF_INCLUDE_OR_EXEMPT_VIEWS` is set to `include`.

This unfortunately breaks caching. For example, Nginx will not cache requests with the `Vary` or `Set-Cookie` headers. This is bad for frequent AJAX GET requests that have no need of the CSRF Token(as one example).

Django gets around this issue by checking to see if the CSRF Token shows up in the request cookies, and checking to see if a token was requested by the template. If explicitly requested (ie by including `{% csrf_token %}` in the template or the CSRF Token in the cookie does not match (non-existent or invalid), the middleware will add the `Set-Cookie` header.

This pull request adds that behavior with clear documentation of what it's doing, as well as adding tests to verify the behavior.