### PR TITLE
feat: use PEP 506 secrets module if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.5
   - 3.6
 install:
-  - pip install flask && pip install nose
+  - pip install flask && pip install nose && pip install mock
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
 script: python setup.py test
 

--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -424,7 +424,12 @@ class SeaSurf(object):
 
     def _generate_token(self):
         '''
-        Generates a token with randomly salted SHA1. Returns a string.
+        Generates a token using PEP 506 secrets module (if available), or falling back to a SHA1-salted random.
         '''
-        salt = str(randrange(0, _MAX_CSRF_KEY)).encode('utf-8')
-        return hashlib.sha1(salt).hexdigest()
+        try:
+            # use PEP 506 secrets module
+            import secrets
+            return secrets.token_hex()
+        except ImportError:
+            salt = str(randrange(0, _MAX_CSRF_KEY)).encode('utf-8')
+            return hashlib.sha1(salt).hexdigest()

--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -40,9 +40,14 @@ else:
 
 
 if hasattr(random, 'SystemRandom'):
-    randrange = random.SystemRandom().randrange
+    random = random.SystemRandom()
 else:
-    randrange = random.randrange
+    random = random
+
+try:
+    import secrets
+except ImportError:
+    secrets = None
 
 REASON_NO_REFERER = u'Referer checking failed: no referer.'
 REASON_BAD_REFERER = u'Referer checking failed: {0} does not match {1}.'
@@ -426,10 +431,9 @@ class SeaSurf(object):
         '''
         Generates a token using PEP 506 secrets module (if available), or falling back to a SHA1-salted random.
         '''
-        try:
+        if secrets:
             # use PEP 506 secrets module
-            import secrets
             return secrets.token_hex()
-        except ImportError:
-            salt = str(randrange(0, _MAX_CSRF_KEY)).encode('utf-8')
+        else:
+            salt = str(random.randrange(0, _MAX_CSRF_KEY)).encode('utf-8')
             return hashlib.sha1(salt).hexdigest()

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -14,6 +14,11 @@ except ImportError:
     # Python >= 2.7
     import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 if sys.version_info[0] < 3:
     b = lambda s: s
 else:
@@ -225,6 +230,17 @@ class SeaSurfTestCase(BaseTestCase):
             self.csrf.validate()
         expected_exception_message = '403 Forbidden: {0}'.format(REASON_NO_REQUEST)
         self.assertEqual(str(ex.exception), expected_exception_message)
+
+    def test_generate_token(self):
+        try:
+            import secrets
+            with mock.patch('secrets.token_hex', return_value='3b0b5a5c1de3c2ed'):
+                self.assertEqual(self.csrf._generate_token(), '3b0b5a5c1de3c2ed')
+        except ImportError:
+            with mock.patch('random.randrange', return_value=4123476):
+                with mock.patch('random.SystemRandom.randrange', return_value=4123476):
+                    self.assertEqual(self.csrf._generate_token(), 'a22372bcac286ccf659ddda312e6311149edd6b0')
+
 
 class SeaSurfTestCaseExemptViews(BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
This module is available starting with Python 3.6 and provides
cryptographically strong pseudo-random numbers suitable for secrets/tokens.

* https://docs.python.org/3/library/secrets.html
* https://www.python.org/dev/peps/pep-0506/