### PR TITLE
add manifest file to fix #61

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.markdown LICENSE


### PR DESCRIPTION
This causes the `LICENSE` file to be included in setuptools distributions and fixes #61.