### PR TITLE
Added the ability to clear the current CSRF token and generate a new one

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -292,6 +292,17 @@ class SeaSurf(object):
             current_app.logger.warning(error)
             raise Forbidden(description=REASON_BAD_TOKEN)
 
+    def generate_new_token(self):
+        '''
+        Delete current CSRF token and generate a new CSRF token.  This function
+        should only be called inside a view function to avoid conflicts with
+        other operations that this library performs during the request context
+        '''
+        new_csrf_token = self._generate_token()
+
+        session[self._csrf_name] = new_csrf_token
+        setattr(_app_ctx_stack.top, self._csrf_name, new_csrf_token)
+
     def _should_use_token(self, view_func):
         '''
         Given a view function, determine whether or not we should deliver a


### PR DESCRIPTION
The ability to generate a new CSRF token is needed for web applications in which session state changes.  For instance, when a user logs into a website, we need the ability to generate a new CSRF token.  Otherwise, a potential attacker could ‘seed’ the anti-CSRF string by accessing the website site, not even requiring them to authenticate to it, and taking note of the anti-CSRF string.  The attacker would then be able to target the next user that logs in to the application in a CSRF attack as the anti-CSRF string is known to them.