### PR TITLE
allow to customize the cookie samesite

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,9 @@ Flask-SeaSurf
 SeaSurf is a Flask extension for preventing `cross-site request forgery (CSRF)
 <https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)>`_.
 
-CSRF vulnerabilities have been found in large and popular sites such as 
-YouTube. These attacks are problematic because the mechanism they use is 
-relatively easy to exploit. This extension attempts to aid you in securing 
+CSRF vulnerabilities have been found in large and popular sites such as
+YouTube. These attacks are problematic because the mechanism they use is
+relatively easy to exploit. This extension attempts to aid you in securing
 your application from such attacks.
 
 This extension is based on the excellent Django middleware.
@@ -31,14 +31,14 @@ or alternatively if you have pip installed::
 Usage
 -----
 
-Using SeaSurf is fairly straightforward. Begin by importing the extension and 
+Using SeaSurf is fairly straightforward. Begin by importing the extension and
 then passing your application object back to the extension, like this:
 
 .. code-block:: python
-    
+
     import Flask
     from flask_seasurf import SeaSurf
-    
+
     app = Flask(__name__)
     csrf = SeaSurf(app)
 
@@ -51,12 +51,13 @@ be added to the Flask app's config file:
 - `CSRF_COOKIE_SECURE` for setting the cookie secure flag
 - `CSRF_COOKIE_PATH` for setting the cookie path
 - `CSRF_COOKIE_DOMAIN` for setting the cookie domain
+- `CSRF_COOKIE_SAMESITE` for setting the cookie samesite
 - `CSRF_DISABLE` to disable CSRF prevention
 
 Except for the last option, all values are passed verbatim to the `Response.set_cookie
 <http://flask.pocoo.org/docs/0.12/api/#flask.Response.set_cookie>`_ method.
 
-Corresponding code will need to be added to the templates where `POST`, `PUT`, 
+Corresponding code will need to be added to the templates where `POST`, `PUT`,
 and `DELETE` HTTP methods are anticipated. In the case of `POST` requests
 a hidden field should be added, something like this:
 
@@ -77,7 +78,7 @@ page. However a view may be completely exempted from validation using the
 exempt decorator. For instance it's possible to decorate a view as shown below:
 
 .. code-block:: python
-    
+
     @csrf.exempt
     @app.route('/exempt_view', methods=['POST'])
     def exempt_view():
@@ -89,7 +90,7 @@ we use strict referer checking to prevent a man-in-the-middle attack from being
 plausible. To disable checking the Referer header, set the Flask app's config
 `CSRF_CHECK_REFERER` to `False`.
 
-.. note:: * Setting ``TESTING = True`` in config will disable the token generation! 
+.. note:: * Setting ``TESTING = True`` in config will disable the token generation!
           * If you are getting ``None`` as token check if ``TESTING = True`` in config.
 
 AJAX Usage
@@ -103,7 +104,7 @@ be better suited to using the `X-CSRFToken` header instead.
 Essentially this header is passed back to the backend by way of extracting the
 token from the cookie using JavaScript. For a better explanation of how this
 might be done please refer to the `Django CSRF documentation
-<https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax>`_. 
+<https://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax>`_.
 
 
 Flask-WTForms Usage

--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -144,6 +144,7 @@ class SeaSurf(object):
         self._csrf_httponly = app.config.get('CSRF_COOKIE_HTTPONLY', False)
         self._csrf_path = app.config.get('CSRF_COOKIE_PATH', '/')
         self._csrf_domain = app.config.get('CSRF_COOKIE_DOMAIN')
+        self._csrf_samesite = app.config.get('CSRF_COOKIE_SAMESITE', 'Lax')
         self._check_referer = app.config.get('CSRF_CHECK_REFERER', True)
         self._type = app.config.get('SEASURF_INCLUDE_OR_EXEMPT_VIEWS',
                                     'exempt')
@@ -407,7 +408,8 @@ class SeaSurf(object):
                             secure=self._csrf_secure,
                             httponly=self._csrf_httponly,
                             path=self._csrf_path,
-                            domain=self._csrf_domain)
+                            domain=self._csrf_domain,
+                            samesite=self._csrf_samesite)
         response.vary.add('Cookie')
 
     def _get_token(self):

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -655,6 +655,17 @@ class SeaSurfTestCaseSetCookie(BaseTestCase):
             res2 = client.post('/bar', headers=headers)
             self.assertEqual(res2.status_code, 200)
 
+    def test_header_set_cookie_samesite(self):
+        samesite = 'Strict'
+        self.app.config['CSRF_COOKIE_SAMESITE'] = samesite
+        self.csrf.init_app(self.app)
+
+        with self.app.test_client() as client:
+            res = client.get('/foo')
+            cookie = res.headers.get('Set-Cookie')
+            c = parse_cookie(cookie)
+            self.assertEqual(c['SameSite'], samesite)
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Customize SameSite to restricts how cookies are sent with requests from external sites.

reference:  
- [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
- [Security Considerations](http://flask.pocoo.org/docs/1.0/security/#set-cookie-options)