### PR TITLE
Change docs URL to avoid redirect

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,4 +34,4 @@ then passing your application object back to the extension, like this:
 
 ## Documentation
 
-The Sphinx-compiled documentation is available here: http://packages.python.org/Flask-SeaSurf/
+The Sphinx-compiled documentation is available here: https://flask-seasurf.readthedocs.io/


### PR DESCRIPTION
Currently, the URL at the bottom of the main README goes to a link which requires a redirect.