### PR TITLE
Fix getCookie implementation in test classes

### DIFF
--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -282,8 +282,8 @@ class SeaSurfTestCaseExemptViews(BaseTestCase):
     def getCookie(self, response, cookie_name):
         cookies = response.headers.getlist('Set-Cookie')
         for cookie in cookies:
-            key, value = list(parse_cookie(cookie).items())[0]
-            if key == cookie_name:
+            value = parse_cookie(cookie).get(cookie_name)
+            if value:
                 return value
         return None
 
@@ -380,8 +380,8 @@ class SeaSurfTestCaseExemptUrls(BaseTestCase):
     def getCookie(self, response, cookie_name):
         cookies = response.headers.getlist('Set-Cookie')
         for cookie in cookies:
-            key, value = list(parse_cookie(cookie).items())[0]
-            if key == cookie_name:
+            value = parse_cookie(cookie).get(cookie_name)
+            if value:
                 return value
         return None
 
@@ -447,8 +447,8 @@ class SeaSurfTestCaseDisableCookie(unittest.TestCase):
     def getCookie(self, response, cookie_name):
         cookies = response.headers.getlist('Set-Cookie')
         for cookie in cookies:
-            key, value = list(parse_cookie(cookie).items())[0]
-            if key == cookie_name:
+            value = parse_cookie(cookie).get(cookie_name)
+            if value:
                 return value
         return None
 
@@ -485,8 +485,8 @@ class SeaSurfTestManualValidation(unittest.TestCase):
     def getCookie(self, response, cookie_name):
         cookies = response.headers.getlist('Set-Cookie')
         for cookie in cookies:
-            key, value = list(parse_cookie(cookie).items())[0]
-            if key == cookie_name:
+            value = parse_cookie(cookie).get(cookie_name)
+            if value:
                 return value
         return None
 


### PR DESCRIPTION
getCookie method included with many of the test suite classes pulls the first item from the dict returned by parse_cookie(). In versions of Python where the dict is not ordered (<=3.5), this may return the session cookie rather than the CSRF token cookie, causing tests to fail. This change to getCookie ensures that the tests don't rely on parse_cookie returned an ordered dict.

Addresses https://github.com/maxcountryman/flask-seasurf/issues/86