### PR TITLE
Add skip_validation decorator to bypass CSRF validation programatically

### DIFF
--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -522,8 +522,8 @@ class SeaSurfTestCaseSkipValidation(unittest.TestCase):
     def getCookie(self, response, cookie_name):
         cookies = response.headers.getlist('Set-Cookie')
         for cookie in cookies:
-            key, value = list(parse_cookie(cookie).items())[0]
-            if key == cookie_name:
+            value = parse_cookie(cookie).get(cookie_name)
+            if value:
                 return value
         return None
 


### PR DESCRIPTION
_Note: this is basically the same as #84, but has been updated with the test fix merged in #88._ 

This allows controlling validation() calls without applying `@exempt` decorator to each endpoint. Useful when performing widespread manual validation (eg through a custom view decorator or before_request hook).

Happy to add documentation if this makes sense to merge.

We've been using this in production via our fork, but would like to get back on the published package if possible.