### PR TITLE
Drop Python 2.6 and 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
 install:
   - pip install flask && pip install nose && pip install mock
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
 script: python setup.py test
 


### PR DESCRIPTION
Flask no longer supports Python 2.6 and 3.3. Since Flask-SeaSurf depends on Flask, we should also drop support for unsupported Python versions.