### PR TITLE
Prevent unhandled exception from invalid referer hosts

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -63,10 +63,13 @@ def _same_origin(url1, url2):
     :param url1: The first URL to compare.
     :param url2: The second URL to compare.
     '''
-    p1, p2 = urlparse.urlparse(url1), urlparse.urlparse(url2)
-    origin1 = p1.scheme, p1.hostname, p1.port
-    origin2 = p2.scheme, p2.hostname, p2.port
-    return origin1 == origin2
+    try:
+        p1, p2 = urlparse.urlparse(url1), urlparse.urlparse(url2)
+        origin1 = p1.scheme, p1.hostname, p1.port
+        origin2 = p2.scheme, p2.hostname, p2.port
+        return origin1 == origin2
+    except ValueError:
+        return False
 
 
 class SeaSurf(object):

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -175,6 +175,21 @@ class SeaSurfTestCase(BaseTestCase):
 
             self.assertEqual(rv.status_code, 200)
 
+    def test_malformed_referer(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                token = self.csrf._generate_token()
+
+                client.set_cookie('www.example.com', self.csrf._csrf_name, token)
+                sess[self.csrf._csrf_name] = token
+
+            rv = client.post('/bar',
+                data={self.csrf._csrf_name: token},
+                base_url='https://www.example.com',
+                headers={'Referer': u'https://foobar:abc'})
+
+            self.assertEqual(403, rv.status_code)
+
     def test_token_in_header(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:


### PR DESCRIPTION
Bad clients can send Referer header with malformed urls, for ex: port that isn't a number.

This change catches the exception from urllib.parse and results in a 403 error instead of 500 error.