### PR TITLE
Use 'hmac.compare_digest' if available

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -27,7 +27,11 @@ from datetime import timedelta
 from flask import (_app_ctx_stack, current_app, g, has_request_context, request,
                    session)
 from werkzeug.exceptions import BadRequest, Forbidden
-from werkzeug.security import safe_str_cmp
+
+try:
+    from hmac import compare_digest as safe_str_cmp
+except ImportError:
+    from werkzeug.security import safe_str_cmp
 
 
 PY3 = sys.version_info[0] >= 3


### PR DESCRIPTION
...instead of `werkzeug.security.safe_str_cmp`, which is [deprecated](https://werkzeug.palletsprojects.com/en/2.0.x/utils/#werkzeug.security.safe_str_cmp) as of Werkzeug 2.0 and emits a DeprecationWarning on usage:

```
flask_seasurf.py:317: DeprecationWarning: 'safe_str_cmp' is deprecated and will be removed in Werkzeug 2.1. Use 'hmac.compare_digest' instead.
  if some_none or not safe_str_cmp(request_csrf_token, server_csrf_token):
```

Note that [`hmac.compare_digest`](https://docs.python.org/3/library/hmac.html#hmac.compare_digest) is available in Python 2.7.7+ and Python 3.3+. In order not to make things worse for older Python versions, we fall back to the old behaviour if it is unavailable.