### PR TITLE
Fix version parsing in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,8 +49,8 @@ copyright = u'2011, Max Countryman'
 
 module_path = os.path.join(os.path.dirname(__file__), '..', 'flask_seasurf.py')
 module_path = os.path.abspath(module_path)
-version_line = filter(lambda l: l.startswith('__version_info__'),
-                      open(module_path))[0]
+version_line = [line for line in open(module_path)
+                if line.startswith('__version_info__')][0]
 
 __version__ = '.'.join(eval(version_line.split('__version_info__ = ')[-1]))
 


### PR DESCRIPTION
Fixes the error when building docs on RTD:

```
Running Sphinx v1.8.6

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/flask-seasurf/envs/stable/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/flask-seasurf/envs/stable/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/flask-seasurf/checkouts/stable/docs/conf.py", line 53, in <module>
    open(module_path))[0]
TypeError: 'filter' object is not subscriptable
```