### PR TITLE
Validate the request is actually json

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -326,7 +326,8 @@ class SeaSurf(object):
         if not request_csrf_token:
             # Check to see if the data is being sent as JSON
             try:
-                if hasattr(request, 'json') and request.json:
+                if hasattr(request, 'is_json') and request.is_json \
+                  and hasattr(request, 'json') and request.json:
                     request_csrf_token = request.json.get(self._csrf_name, '')
 
             # Except Attribute error if JSON data is a list


### PR DESCRIPTION
When using flask_json you can cause a JsonError to be raised even if you call hasattr(request, 'json') and the request has an empty body