### PR TITLE
Catch TypeError comparing strings with non-ASCII characters is not supported

### DIFF
--- a/flask_seasurf.py
+++ b/flask_seasurf.py
@@ -338,8 +338,7 @@ class SeaSurf(object):
             # PUT and DELETE possible.
             request_csrf_token = request.headers.get(self._csrf_header_name, '')
 
-        some_none = None in (request_csrf_token, server_csrf_token)
-        if some_none or not safe_str_cmp(request_csrf_token, server_csrf_token):
+        if not self._safe_str_cmp(request_csrf_token, server_csrf_token):
             error = (REASON_BAD_TOKEN, request.path)
             error = u'Forbidden ({0}): {1}'.format(*error)
             current_app.logger.warning(error)
@@ -521,3 +520,16 @@ class SeaSurf(object):
         else:
             salt = str(random.randrange(0, _MAX_CSRF_KEY)).encode('utf-8')
             return hashlib.sha1(salt).hexdigest()
+
+    def _safe_str_cmp(self, a, b):
+        '''
+        Compares two strings for equality while preventing timing attacks.
+        '''
+
+        if a is None or b is None:
+            return False
+
+        try:
+            return safe_str_cmp(a, b)
+        except:
+            return False

--- a/test_seasurf.py
+++ b/test_seasurf.py
@@ -116,6 +116,19 @@ class SeaSurfTestCase(BaseTestCase):
             rv = client.post(u'/bar/\xf8', data=data)
             self.assertEqual(rv.status_code, 200, rv)
 
+    def test_token_with_non_ascii_chars(self):
+        """Should fail with 403"""
+        tokenA = self.csrf._generate_token()
+        tokenB = '🥳'
+        data = {'_csrf_token': tokenB}
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess[self.csrf._csrf_name] = tokenA
+                client.set_cookie('www.example.com', self.csrf._csrf_name, tokenB)
+
+            rv = client.post('/bar', data=data)
+            self.assertEqual(rv.status_code, 403, rv)
+
     def test_https_bad_referer(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:


### PR DESCRIPTION
When a malicious user changes the csrf token value to contain non-ASCII characters, Flask-SeaSurf raises a `TypeError`. This prevents that error by catching and evaluating the strings as not matching.